### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-
 language: node_js
 
 node_js:
@@ -9,9 +7,12 @@ os:
   - linux
   - osx
 
+before_install:
+  - curl https://install.meteor.com | /bin/sh
+  - export PATH="$HOME/.meteor:$PATH"
+
 install:
   - npm install
-  - sudo curl http://install.meteor.com | /bin/sh
   - node --version
   - meteor --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
+sudo: required
+
+language: node_js
+
+node_js:
+  - "0.10.40"
+
 os:
   - linux
   - osx
 
 install:
-  - rm -rf ~/.nvm
-  - git clone https://github.com/creationix/nvm.git ~/.nvm
-  - source ~/.nvm/nvm.sh
-  - nvm install 0.10.40
-  - nvm use 0.10.40
   - npm install
   - sudo curl http://install.meteor.com | /bin/sh
   - node --version


### PR DESCRIPTION
Uses built-in `nvm` implementation in Travis CI
Also fixes `meteor: command not found` issue on Travis CI
